### PR TITLE
Enhancement.icall tmsh

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 				},
 				{
 					"id": "as3Tasks",
-					"name": "iRules/iApps",
+					"name": "Tcl Objects",
 					"when": "f5.tcl"
 				},
 				{

--- a/src/tclCore.ts
+++ b/src/tclCore.ts
@@ -57,7 +57,7 @@ export default function tclCore(context: ExtensionContext) {
         return tclTreeProvider.deleteRule(rule);
     }));
 
-    // --- ICALL COMMANDS ---
+    // --- ICALL Script COMMANDS ---
     context.subscriptions.push(commands.registerCommand('f5-tcl.getIcallscript', async (icallscript) => {
         return tclTreeProvider.displayIcallscript(icallscript);
     }));
@@ -67,6 +67,14 @@ export default function tclCore(context: ExtensionContext) {
     }));
 
 
+    // --- TMSH Script COMMANDS ---
+    context.subscriptions.push(commands.registerCommand('f5-tcl.getTMSHscript', async (tmshscript) => {
+        return tclTreeProvider.displayTMSHscript(tmshscript);
+    }));
+
+    context.subscriptions.push(commands.registerCommand('f5-tcl.deleteTMSHscript', async (tmshscript) => {
+        return tclTreeProvider.deleteTMSHscript(tmshscript);
+    }));
 
 
     // --- IAPP COMMANDS ---

--- a/src/tclCore.ts
+++ b/src/tclCore.ts
@@ -57,6 +57,14 @@ export default function tclCore(context: ExtensionContext) {
         return tclTreeProvider.deleteRule(rule);
     }));
 
+    // --- ICALL COMMANDS ---
+    context.subscriptions.push(commands.registerCommand('f5-tcl.getIcallscript', async (icallscript) => {
+        return tclTreeProvider.displayIcallscript(icallscript);
+    }));
+
+    context.subscriptions.push(commands.registerCommand('f5-tcl.deleteIcallscript', async (icallscript) => {
+        return tclTreeProvider.deleteIcallscript(icallscript);
+    }));
 
 
 

--- a/src/treeViewsProviders/tclTreeProvider.ts
+++ b/src/treeViewsProviders/tclTreeProvider.ts
@@ -34,6 +34,7 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 	readonly onDidChangeTreeData: Event<TCLitem | undefined> = this._onDidChangeTreeData.event;
 
 	private _iRules: string[] = [];  
+	private _iCallScripts: string[] = [];
 	private _apps: string[] = [];  
 	private _iAppTemplates: string[] = [];
 
@@ -69,6 +70,14 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
                         { command: 'f5-tcl.getRule', title: '', arguments: [el] });
                 });
 				
+			} else if (element.label === 'iCall-Scripts'){
+				treeItems = this._iCallScripts.map( (el: any) => {
+                	const content = `sys icall script ${el.fullPath} {\r\n` + el.definition + '\r\n}';
+                    const toolTip = new MarkdownString()
+                    .appendCodeblock(content, 'irule-lang');
+		    		return new TCLitem(el.fullPath, '', '', 'iCallScript', TreeItemCollapsibleState.None,
+						{ command: 'f5-tcl.getIcallscript', title: '', arguments: [el] });
+				});
 			} else if (element.label === 'Deployed-Apps'){
 				// todo: get iapps stuff
 				treeItems = this._apps.map( (el: any) => {
@@ -82,20 +91,26 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
                     return new TCLitem(el.fullPath, '', '', 'iAppTemplate', TreeItemCollapsibleState.None, 
                         { command: 'f5-tcl.getTMPL', title: '', arguments: [el] });
                 });
-			}
+			} 
 
 		} else {
 
 			await this.getIrules(); // refresh tenant information
+			await this.getIcallscripts(); // refresh tenant information
 			await this.getApps();	// refresh tasks information
 			await this.getTemplates();	// refresh tasks information
 
 			const ruleCount = this._iRules.length !== 0 ? this._iRules.length.toString() : '';
+			const icallscriptsCount = this._iCallScripts.length !== 0 ? this._iCallScripts.length.toString() : '';
 			const appCount = this._apps.length !== 0 ? this._apps.length.toString() : '';
 			const tempCount = this._iAppTemplates.length !== 0 ? this._iAppTemplates.length.toString() : '';
 
 			treeItems.push(
 				new TCLitem('iRules', ruleCount, '', '', TreeItemCollapsibleState.Collapsed, 
+					{ command: '', title: '', arguments: [''] })
+			);
+			treeItems.push(
+				new TCLitem('iCall-Scripts', icallscriptsCount, '', '', TreeItemCollapsibleState.Collapsed,
 					{ command: '', title: '', arguments: [''] })
 			);
 			treeItems.push(
@@ -121,6 +136,15 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 		
 		await ext.f5Client?.https(`/mgmt/tm/ltm/rule`)
 		.then( resp => this._iRules = resp.data.items );
+	}
+
+	/**
+	 * Get all iCall scripts to hold in "this" view class
+	 */
+	private async getIcallscripts() {
+	this._iCallScripts = []
+		await ext.f5Client?.https(`/mgmt/tm/sys/icall/script`)
+		.then( resp => this._iCallScripts = resp.data.items );
 	}
 
 	/**
@@ -192,6 +216,43 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 			return `${resp.status}-${resp.statusText}`;
 		});
 	}
+
+
+
+	/**
+	 * crafts iCall tcl object and displays in editor with icall language
+	 * @param item iCule item passed from view click
+	 */
+	async displayIcallscript(item: any) {
+
+		// make it look like a tcl irule object so it can be merged back with changes
+		const content = `sys icall script ${item.fullPath} {\r\n` + item.definition + '\r\n}';
+
+		// open editor and feed it the content
+		const doc = await workspace.openTextDocument({ content: content, language: 'icallscript-lang' });
+		// make the editor appear
+		await window.showTextDocument( doc, { preview: false });
+		return doc;	// return something for automated testing
+	}
+	
+	async deleteIcallscript(item: any) {
+		logger.debug('deleteIcallscript: ', item);
+
+		const name = this.name2uri(item.label);
+
+		// const resp: any = await ext.mgmtClient?.makeRequest(`/mgmt/tm/sys/icall/script/${name}`, {
+		// 	method: 'DELETE'
+		// });
+
+		const resp = await ext.f5Client?.https(`/mgmt/tm/sys/icall/script/${name}`, {
+			method: 'DELETE'
+		})
+		.then (resp => {
+			setTimeout( () => { this.refresh();}, 500);	// refresh after update
+			return `${resp.status}-${resp.statusText}`;
+		});
+	}
+
 
 	/**
 	 * display .tmpl from f5 in editor

--- a/src/treeViewsProviders/tclTreeProvider.ts
+++ b/src/treeViewsProviders/tclTreeProvider.ts
@@ -74,7 +74,7 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 				treeItems = this._iCallScripts.map( (el: any) => {
                 	const content = `sys icall script ${el.fullPath} {\r\n` + el.definition + '\r\n}';
                     const toolTip = new MarkdownString()
-                    .appendCodeblock(content, 'irule-lang');
+                    .appendCodeblock(content, 'icallscript-lang');
 		    		return new TCLitem(el.fullPath, '', '', 'iCallScript', TreeItemCollapsibleState.None,
 						{ command: 'f5-tcl.getIcallscript', title: '', arguments: [el] });
 				});

--- a/src/treeViewsProviders/tclTreeProvider.ts
+++ b/src/treeViewsProviders/tclTreeProvider.ts
@@ -35,6 +35,7 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 
 	private _iRules: string[] = [];  
 	private _iCallScripts: string[] = [];
+	private _TMSHScripts: string[] = [];
 	private _apps: string[] = [];  
 	private _iAppTemplates: string[] = [];
 
@@ -70,22 +71,30 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
                         { command: 'f5-tcl.getRule', title: '', arguments: [el] });
                 });
 				
-			} else if (element.label === 'iCall-Scripts'){
+			} else if (element.label === 'iCall Scripts'){
 				treeItems = this._iCallScripts.map( (el: any) => {
-                	const content = `sys icall script ${el.fullPath} {\r\n` + el.definition + '\r\n}';
+                	const content = `sys icall script ${el.fullPath} {\r\n` + `definition {\r\n` + el.definition + '\r\n}\r\n}';
                     const toolTip = new MarkdownString()
-                    .appendCodeblock(content, 'icallscript-lang');
-		    		return new TCLitem(el.fullPath, '', '', 'iCallScript', TreeItemCollapsibleState.None,
+                    .appendCodeblock(content, 'irule-lang');
+		    		return new TCLitem(el.fullPath, '', toolTip, 'iCallScript', TreeItemCollapsibleState.None,
 						{ command: 'f5-tcl.getIcallscript', title: '', arguments: [el] });
 				});
-			} else if (element.label === 'Deployed-Apps'){
+			} else if (element.label === 'TMSH Scripts'){
+				treeItems = this._TMSHScripts.map( (el: any) => {
+                	const content = `cli script ${el.fullPath} {\r\n` + el.apiAnonymous + '\r\n}';
+                    const toolTip = new MarkdownString()
+                    .appendCodeblock(content, 'irule-lang');
+		    		return new TCLitem(el.fullPath, '', toolTip, 'tmshScript', TreeItemCollapsibleState.None,
+						{ command: 'f5-tcl.getTMSHscript', title: '', arguments: [el] });
+				});
+			} else if (element.label === 'iApps (Deployed)'){
 				// todo: get iapps stuff
 				treeItems = this._apps.map( (el: any) => {
                     return new TCLitem(el.fullPath, '', '', 'iApp', TreeItemCollapsibleState.None, 
                         { command: 'f5-tcl.getApp', title: '', arguments: [el] });
 				});
 				
-			} else if (element.label === 'iApp-Templates'){
+			} else if (element.label === 'iApps (Templates)'){
 				// todo: get iapp templates stuff
 				treeItems = this._iAppTemplates.map( (el: any) => {
                     return new TCLitem(el.fullPath, '', '', 'iAppTemplate', TreeItemCollapsibleState.None, 
@@ -97,11 +106,13 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 
 			await this.getIrules(); // refresh tenant information
 			await this.getIcallscripts(); // refresh tenant information
+			await this.getTMSHscripts(); // refresh tenant information
 			await this.getApps();	// refresh tasks information
 			await this.getTemplates();	// refresh tasks information
 
 			const ruleCount = this._iRules.length !== 0 ? this._iRules.length.toString() : '';
 			const icallscriptsCount = this._iCallScripts.length !== 0 ? this._iCallScripts.length.toString() : '';
+			const TMSHscriptsCount = this._TMSHScripts.length !== 0 ? this._TMSHScripts.length.toString() : '';
 			const appCount = this._apps.length !== 0 ? this._apps.length.toString() : '';
 			const tempCount = this._iAppTemplates.length !== 0 ? this._iAppTemplates.length.toString() : '';
 
@@ -110,15 +121,19 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 					{ command: '', title: '', arguments: [''] })
 			);
 			treeItems.push(
-				new TCLitem('iCall-Scripts', icallscriptsCount, '', '', TreeItemCollapsibleState.Collapsed,
+				new TCLitem('iCall Scripts', icallscriptsCount, '', '', TreeItemCollapsibleState.Collapsed,
 					{ command: '', title: '', arguments: [''] })
 			);
 			treeItems.push(
-				new TCLitem('Deployed-Apps', appCount, '', '', TreeItemCollapsibleState.Collapsed,
+				new TCLitem('TMSH Scripts', TMSHscriptsCount, '', '', TreeItemCollapsibleState.Collapsed,
 					{ command: '', title: '', arguments: [''] })
 			);
 			treeItems.push(
-				new TCLitem('iApp-Templates', tempCount, '', '', TreeItemCollapsibleState.Collapsed,
+				new TCLitem('iApps (Deployed)', appCount, '', '', TreeItemCollapsibleState.Collapsed,
+					{ command: '', title: '', arguments: [''] })
+			);
+			treeItems.push(
+				new TCLitem('iApps (Templates)', tempCount, '', '', TreeItemCollapsibleState.Collapsed,
 					{ command: '', title: '', arguments: [''] })
 			);
 		}
@@ -146,6 +161,15 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 		await ext.f5Client?.https(`/mgmt/tm/sys/icall/script`)
 		.then( resp => this._iCallScripts = resp.data.items );
 	}
+
+	/**
+	 * Get all TMSH scripts to hold in "this" view class
+	 */
+	 private async getTMSHscripts() {
+		this._TMSHScripts = []
+			await ext.f5Client?.https(`/mgmt/tm/cli/script`)
+			.then( resp => this._TMSHScripts = resp.data.items );
+		}
 
 	/**
 	 * Get all deployed iApp-Apps to hold in "this" view class
@@ -218,7 +242,6 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 	}
 
 
-
 	/**
 	 * crafts iCall tcl object and displays in editor with icall language
 	 * @param item iCule item passed from view click
@@ -226,10 +249,10 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 	async displayIcallscript(item: any) {
 
 		// make it look like a tcl irule object so it can be merged back with changes
-		const content = `sys icall script ${item.fullPath} {\r\n` + item.definition + '\r\n}';
+		const content = `sys icall script ${item.fullPath} {\r\n` + `definition {\r\n` + item.definition + '\r\n}\r\n}';
 
 		// open editor and feed it the content
-		const doc = await workspace.openTextDocument({ content: content, language: 'icallscript-lang' });
+		const doc = await workspace.openTextDocument({ content: content, language: 'irule-lang' });
 		// make the editor appear
 		await window.showTextDocument( doc, { preview: false });
 		return doc;	// return something for automated testing
@@ -245,6 +268,40 @@ export class TclTreeProvider implements TreeDataProvider<TCLitem> {
 		// });
 
 		const resp = await ext.f5Client?.https(`/mgmt/tm/sys/icall/script/${name}`, {
+			method: 'DELETE'
+		})
+		.then (resp => {
+			setTimeout( () => { this.refresh();}, 500);	// refresh after update
+			return `${resp.status}-${resp.statusText}`;
+		});
+	}
+
+	/**
+	 * crafts tmsh script tcl object and displays in editor with tmsh language
+	 * @param item tmsh script item passed from view click
+	 */
+	 async displayTMSHscript(item: any) {
+		
+		// make it look like a tcl tmsh script object so it can be merged back with changes
+		const content = `cli script ${item.fullPath} {\r\n` + item.apiAnonymous + '\r\n}';
+
+		// open editor and feed it the content
+		const doc = await workspace.openTextDocument({ content: content, language: 'irule-lang' });
+		// make the editor appear
+		await window.showTextDocument( doc, { preview: false });
+		return doc;	// return something for automated testing
+	}
+
+	async deleteTMSHscript(item: any) {
+		logger.debug('deleteTMSHscript: ', item);
+
+		const name = this.name2uri(item.label);
+
+		// const resp: any = await ext.mgmtClient?.makeRequest(`/mgmt/tm/cli/script/${name}`, {
+		// 	method: 'DELETE'
+		// });
+
+		const resp = await ext.f5Client?.https(`/mgmt/tm/cli/script/${name}`, {
 			method: 'DELETE'
 		})
 		.then (resp => {


### PR DESCRIPTION
Adds support for:
- iCall scripts
- TMSH scripts

Modifies the nomenclature for:
- IRULES/IAPPS navigation, is now: TCL OBJECTS
- iCall Scripts added to menu
- TMSH Scripts added to menu
- Deployed-Apps, is now: iApps (Deployed)
- iApp-Templates, is now: iApps (Templates)